### PR TITLE
Make links that go external open page in a new tab

### DIFF
--- a/views/gallery.jade
+++ b/views/gallery.jade
@@ -15,13 +15,13 @@ block content
                 | Want to see photos of the wedding? 
             p 
                 | Be sure to use 
-                a(href="https://tagboard.com/toasttoposton/search")= "#ToastToPoston"
+                a(href="https://tagboard.com/toasttoposton/search", target="_blank")= "#ToastToPoston"
                 |  on your
-                a(href="https://instagram.com/explore/tags/toasttoposton/")=" Instagram"
+                a(href="https://instagram.com/explore/tags/toasttoposton/", target="_blank")=" Instagram"
                 | ,
-                a(href="https://twitter.com/hashtag/toasttoposton")= " Twitter"
+                a(href="https://twitter.com/hashtag/toasttoposton", target="_blank")= " Twitter"
                 | , and
-                a(href="https://www.facebook.com/hashtag/toasttoposton")=" Facebook!"
+                a(href="https://www.facebook.com/hashtag/toasttoposton", target="_blank")=" Facebook!"
         div.row.grid
             each value, index in galleryPhotos
                 +thumbnail(value, index)


### PR DESCRIPTION
In order to keep people on the website longer make sure that the links
that lead to external websites/pages open the destination in a new
tab/window.

Closes #11
