### PR TITLE
Make the correct picture is displayed when a thumbnail is clicked

### DIFF
--- a/public/javascripts/site.js
+++ b/public/javascripts/site.js
@@ -50,3 +50,13 @@ $(window).load(function() {
     $('.grid').masonry();
 });
 $(window).resize(adjustContentsTop);
+
+$('#galleryModal').on('show.bs.modal', function (event) {
+    var thumbnail = $(event.relatedTarget);
+    var imageIndex = thumbnail.data('index');
+
+    var modal = $(this);
+
+    modal.find('.active').removeClass('.active');
+    modal.find('ol.carousel-indicators > li')[imageIndex].click();
+});


### PR DESCRIPTION
When a thumbnail is clicked the photo that was clicked should be
displayed in the modal.

Closes #4
